### PR TITLE
fixes for libgazebo7-dev compatibility

### DIFF
--- a/src/ContactPlugin.cc
+++ b/src/ContactPlugin.cc
@@ -27,8 +27,7 @@ ContactPlugin::~ContactPlugin()
 void ContactPlugin::Load(sensors::SensorPtr _sensor, sdf::ElementPtr /*_sdf*/)
 {
   // get the parent sensor
-  this->parentSensor = boost::dynamic_pointer_cast<sensors::ContactSensor>(
-      _sensor);
+  this->parentSensor = std::dynamic_pointer_cast<sensors::ContactSensor>(_sensor);
 
   // make sure the parent sensor is valid
   if (!this->parentSensor)
@@ -50,7 +49,7 @@ void ContactPlugin::OnUpdate()
 {
   // Get all the contacts.
   msgs::Contacts contacts;
-  contacts = this->parentSensor->GetContacts();
+  contacts = this->parentSensor->Contacts();
   for (unsigned int i = 0; i < contacts.contact_size(); ++i)
   {
 	  std::cout << "Collision between[" << contacts.contact(i).collision1()

--- a/src/UarmPublisher.cc
+++ b/src/UarmPublisher.cc
@@ -2,7 +2,7 @@
 
 UarmPublisher::UarmPublisher()
 {
-  gazebo::load();
+  gazebo::common::load();
   gazebo::transport::init();
   gazebo::transport::run();
   gazebo::transport::NodePtr node(new gazebo::transport::Node());


### PR DESCRIPTION
Fixed deprecated methods to bring the ContactPlugin and UarmPublisher up to date w/ libgazebo7 so that UarmPub works with Gazebo 7. Tested successfully on Gazebo 7.0.1 and 7.5